### PR TITLE
Add packaging information to build system.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ include(PkgConfigVars)
 add_definitions("-std=c99 -Wall")
 add_definitions(-DG_LOG_DOMAIN="Uca-Pco")
 
-pkg_check_modules(UCA libuca>=2.0.0 REQUIRED)
+pkg_check_modules(UCA libuca>=2.1.0 REQUIRED)
 pkg_check_variable(libuca plugindir)
 
 
@@ -48,3 +48,29 @@ target_link_libraries(ucapco
 
 install(TARGETS ucapco
     LIBRARY DESTINATION ${LIBUCA_PLUGINDIR})
+
+# --- Packaging specific ---------------------------------------------------------
+
+set(VERSION 1.2.2)
+set(RELEASE 1)
+
+set(CPACK_GENERATOR "RPM")
+set(CPACK_PACKAGE_NAME "uca-plugin-pco")
+set(CPACK_PACKAGE_VERSION ${VERSION})
+set(CPACK_PACKAGE_RELEASE ${RELEASE})
+set(CPACK_RPM_PACKAGE_RELEASE ${RELEASE})
+set(CPACK_PACKAGE_VENDOR "ANKA Computing Group")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Uca plugin for the pco detector family.")
+set(CPACK_PACKAGE_DESCRIPTION_FILE "${CMAKE_CURRENT_SOURCE_DIR}/package_description.txt")
+
+set(CPACK_PACKAGING_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
+set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CPACK_PACKAGE_RELEASE}.${CMAKE_SYSTEM_PROCESSOR}")
+
+set(CPACK_RPM_PACKAGE_REQUIRES "libuca >= 2.1, libpco >= 1.0, siso-rt5 >= 5.2")
+
+set(CPACK_RPM_PACKAGE_GROUP "Hardware/Camera")
+set(CPACK_RPM_CHANGELOG_FILE "${CMAKE_CURRENT_SOURCE_DIR}/package_changelog.txt")
+
+include(CPack)
+
+

--- a/package_changelog.txt
+++ b/package_changelog.txt
@@ -1,0 +1,3 @@
+* Tue Aug 04 2015 Mihael Koep <mihael.koep@softwareschneiderei.de> 1.2.2-1
+- First independent packaging of PCO plugin
+- Fixed timeout handling with external triggering

--- a/package_description.txt
+++ b/package_description.txt
@@ -1,0 +1,3 @@
+Uca plugin for the pco detector family.
+
+The plugin has been tested successfully with the pco.4000, pco.edge and pco.dimax detectors.


### PR DESCRIPTION
Would you like to include CPack packaging in the independently distributed uca plugins? You may change the vendor of course if you see a better fit!
