### PR TITLE
Fixes the state of the pco4000

### DIFF
--- a/uca-pco-camera.c
+++ b/uca-pco-camera.c
@@ -1027,7 +1027,7 @@ uca_pco_camera_get_property (GObject *object, guint property_id, GValue *value, 
 
     /* Should fix #20 */
     if (priv->description->type == CAMERATYPE_PCO4000) {
-        if (priv->is_recording) {
+        if (priv->is_recording && property_id != PROP_IS_RECORDING) {
             return;
         }
     }


### PR DESCRIPTION
The is_recording property was always false for the pco4000 since in the recording state no properties where readable.
This blocks now only the polling of properties different to is_recording in the recording state.